### PR TITLE
Update the DataFrame in AutoRequest

### DIFF
--- a/uottawa_scheduler/__init__.py
+++ b/uottawa_scheduler/__init__.py
@@ -60,6 +60,7 @@ def refresh_data(s, df):
 def auto_request(s, df, session_code, request_time, baseline_link):
     count = 0
     while list(df[df['barcode'] == session_code].to_dict().get('links').values())[0] == 0:
+        df = refresh_data(s,df)
         time.sleep(request_time * 0.001)
         count += 1
         print(count)


### PR DESCRIPTION
Without updating the dataframe, we end up in an infinite loop if we start the program with an unavailable gym slot, even if it becomes available in the future.